### PR TITLE
Fix(firebase_messaging): critical of sound causing a hidden error

### DIFF
--- a/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/remote_notification.dart
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/remote_notification.dart
@@ -55,7 +55,7 @@ class RemoteNotification {
           sound: map['apple']['sound'] == null
               ? null
               : AppleNotificationSound(
-                  critical: map['apple']['sound']['critical'],
+                  critical: map['apple']['sound']['critical'] ?? false,
                   name: map['apple']['sound']['name'],
                   volume: map['apple']['sound']['volume']));
     }


### PR DESCRIPTION
## Description

map['apple']['sound']['critical'] can be null because critical of sound is optional.
When map['apple']['sound']['critical'] is null, the TypeError raises
Because critical is non-nullable.

## Related Issues
None

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
